### PR TITLE
Use symvar instead of findsym.

### DIFF
--- a/@polynomial/kron.m
+++ b/@polynomial/kron.m
@@ -1,4 +1,4 @@
-function b = kron(x,y)
+function c = kron(a,b)
 % function B = kron(X,Y)
 %
 % DESCRIPTION
@@ -24,25 +24,33 @@ if nargin~=2
     %narginchk(2,2);
 end
 
+a = polynomial(a);
+b = polynomial(b);
+
 % Get matrix dimensions
-[rx,cx] = size(x);
-[ry,cy] = size(y);
+sza = size(a);
+szb = size(b);
 
-% Inialize variable for parentheses subsref
-L.type = '()';
-L.subs = {};
+% Get polynomial info
+acoef = a.coefficient;  bcoef = b.coefficient;
+adeg  = a.degmat;       bdeg  = b.degmat;
 
-% Perform KRON operation 
-% Note: This is probably not the most efficient implementation for polys
-b = polynomial( zeros(rx*ry,cx*cy) );
-for i = 1:rx
-    for j = 1:cx
-        L.subs = {i,j};
-        xij = subsref(x,L);
-        
-        ridx = (1:ry)+(i-1)*ry;
-        cidx = (1:cy)+(j-1)*cy;
-        L.subs = {ridx,cidx};
-        b = subsasgn(b,L,xij*y);
-    end
+% number of terms & elements
+[ant,ane] = size(acoef);
+[bnt,bne] = size(bcoef);
+
+% variables of x and y
+[Ia,Ib] = ndgrid(1:ant,1:bnt);
+ja = reshape(kron(reshape(1:ane,sza),ones(szb)),[],1);
+jb = reshape(kron(ones(sza),reshape(1:bne,szb)),[],1);
+
+matdim = sza.*szb;
+degmat = [adeg(Ia(:),:) bdeg(Ib(:),:)];
+coefficient = acoef(Ia(:),ja(:)).*bcoef(Ib(:),jb(:));
+
+[degmat,vars] = PVuniquevar(degmat,[a.varname b.varname]);
+[coefficient,degmat] = PVuniqueterm(coefficient,degmat,matdim);
+
+c = polynomial(coefficient,degmat,vars,matdim);
+
 end

--- a/s2p.m
+++ b/s2p.m
@@ -17,6 +17,8 @@ function p=s2p(s)
 
 % 1/30/2003: PJS  Initial Coding
 % 11/23/2010 PJS  Updated for matrix polynomials and to use sym/eval
+% 5/5/2021   TC   Use symvar instead of findsym 
+%                 (removed long since, thanks to Huang Hejun for pointing out!)
 
 if ~isa(s,'sym')
     error('Input must be a symbolic toolbox object');
@@ -26,15 +28,10 @@ end
 s = vpa(s);
 
 % Create pvars for each variable in s
-vars = findsym(s);
-if isempty(vars)
-    nv = 0;
-else
-    vidx = [0 strfind(vars,',') length(vars)+1];
-    nv = length(vidx)-1;
-end
-for i1 =1:nv
-    varname = vars(vidx(i1)+1 : vidx(i1+1)-1);
+vars = symvar(s);
+
+for i1 =1:length(vars)
+    varname = char(vars(i1));
     pvar(varname);
 end
 


### PR DESCRIPTION
Mathworks stopped supporting the function `findsym` long ago (thanks to Huang Hejun for opening issue #1). This pull request replaces the previous implementation by using [`symvar`](https://www.mathworks.com/help/symbolic/symvar.html) instead.